### PR TITLE
mysql과 redis에서 동시성 제어 이슈 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
+.env
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
@@ -17,8 +17,7 @@ public class CouponIssueRequestService {
 
 
     public void issueRequestV1(CouponIssueRequestDto couponIssueRequestDto) {
-        distributeLockExecutor.execute("lock_" + couponIssueRequestDto.couponId(), 10000, 10000,
-                () -> couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId()));
+        couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId());
         log.info("쿠폰 발급 요청 완료. userId: {}, couponId: {}", couponIssueRequestDto.userId(), couponIssueRequestDto.couponId());
     }
 }

--- a/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
@@ -15,7 +15,9 @@ public class CouponIssueRequestService {
 
 
     public void issueRequestV1(CouponIssueRequestDto couponIssueRequestDto) {
-        couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId());
-        log.info("쿠폰 발급 요청이 완료되었습니다. userId: {}, couponId: {}", couponIssueRequestDto.userId(), couponIssueRequestDto.couponId());
+        synchronized (this) {
+            couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId());
+        }
+        log.info("쿠폰 발급 요청 완료. userId: {}, couponId: {}", couponIssueRequestDto.userId(), couponIssueRequestDto.couponId());
     }
 }

--- a/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/cmj/couponapi/service/CouponIssueRequestService.java
@@ -1,6 +1,7 @@
 package com.cmj.couponapi.service;
 
 import com.cmj.couponapi.controller.dto.CouponIssueRequestDto;
+import com.cmj.couponcore.component.DistributeLockExecutor;
 import com.cmj.couponcore.service.CouponIssueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,12 +13,12 @@ import org.springframework.stereotype.Service;
 public class CouponIssueRequestService {
 
     private final CouponIssueService couponIssueService;
+    private final DistributeLockExecutor distributeLockExecutor;
 
 
     public void issueRequestV1(CouponIssueRequestDto couponIssueRequestDto) {
-        synchronized (this) {
-            couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId());
-        }
+        distributeLockExecutor.execute("lock_" + couponIssueRequestDto.couponId(), 10000, 10000,
+                () -> couponIssueService.issue(couponIssueRequestDto.couponId(), couponIssueRequestDto.userId()));
         log.info("쿠폰 발급 요청 완료. userId: {}, couponId: {}", couponIssueRequestDto.userId(), couponIssueRequestDto.couponId());
     }
 }

--- a/coupon-api/src/test/java/com/cmj/couponapi/CouponApiApplicationTests.java
+++ b/coupon-api/src/test/java/com/cmj/couponapi/CouponApiApplicationTests.java
@@ -2,7 +2,11 @@ package com.cmj.couponapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.config.name=application-core")
 @SpringBootTest
 class CouponApiApplicationTests {
 

--- a/coupon-consumer/src/test/java/com/cmj/couponconsumer/CouponConsumerApplicationTests.java
+++ b/coupon-consumer/src/test/java/com/cmj/couponconsumer/CouponConsumerApplicationTests.java
@@ -2,7 +2,11 @@ package com.cmj.couponconsumer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.config.name=application-core")
 @SpringBootTest
 class CouponConsumerApplicationTests {
 

--- a/coupon-core/src/main/java/com/cmj/couponcore/component/DistributeLockExecutor.java
+++ b/coupon-core/src/main/java/com/cmj/couponcore/component/DistributeLockExecutor.java
@@ -1,0 +1,33 @@
+package com.cmj.couponcore.component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DistributeLockExecutor {
+
+    private final RedissonClient redissonClient;
+
+    public void execute(String lockName, long waitMilliSecond, long leaseMilliSecond, Runnable runnable) {
+        RLock lock = redissonClient.getLock(lockName);
+        try {
+            boolean isLocked = lock.tryLock(waitMilliSecond, leaseMilliSecond, TimeUnit.MILLISECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("Lock을 획득하지 못했습니다. lockName: %s".formatted(lockName));
+            }
+            runnable.run();
+        } catch (InterruptedException e) {
+            log.error("Lock 획득 중 문제가 발생했습니다. lockName: %s".formatted(lockName), e);
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/coupon-core/src/main/java/com/cmj/couponcore/configuration/RedisConfiguration.java
+++ b/coupon-core/src/main/java/com/cmj/couponcore/configuration/RedisConfiguration.java
@@ -1,0 +1,27 @@
+package com.cmj.couponcore.configuration;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+
+    @Bean
+    RedissonClient redissonClient() {
+        Config config = new Config();
+        String address = "redis://" + host + ":" + port;
+        config.useSingleServer().setAddress(address);
+        return Redisson.create(config);
+    }
+}

--- a/coupon-core/src/main/java/com/cmj/couponcore/repository/mysql/CouponJpaRepository.java
+++ b/coupon-core/src/main/java/com/cmj/couponcore/repository/mysql/CouponJpaRepository.java
@@ -1,7 +1,16 @@
 package com.cmj.couponcore.repository.mysql;
 
 import com.cmj.couponcore.model.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Coupon c where c.id = :id")
+    Optional<Coupon> findCouponWithLock(long id);
 }

--- a/coupon-core/src/main/java/com/cmj/couponcore/service/CouponIssueService.java
+++ b/coupon-core/src/main/java/com/cmj/couponcore/service/CouponIssueService.java
@@ -24,10 +24,9 @@ public class CouponIssueService {
     private final CouponIssueRepository couponIssueRepository;
 
     public void issue(long couponId, long userId) {
-        Coupon coupon = couponJpaRepository.findById(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
-        coupon.issue();
-
-        saveCouponIssue(couponId, userId);
+            Coupon coupon = couponJpaRepository.findById(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
+            coupon.issue();
+            saveCouponIssue(couponId, userId);
     }
 
     public CouponIssue saveCouponIssue(long couponId, long userId) {

--- a/coupon-core/src/main/java/com/cmj/couponcore/service/CouponIssueService.java
+++ b/coupon-core/src/main/java/com/cmj/couponcore/service/CouponIssueService.java
@@ -24,9 +24,17 @@ public class CouponIssueService {
     private final CouponIssueRepository couponIssueRepository;
 
     public void issue(long couponId, long userId) {
-            Coupon coupon = couponJpaRepository.findById(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
+            Coupon coupon = findCouponWithLock(couponId);
             coupon.issue();
             saveCouponIssue(couponId, userId);
+    }
+
+    public Coupon findCouponWithLock(long couponId) {
+        return couponJpaRepository.findCouponWithLock(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
+    }
+
+    public Coupon findCoupon(long couponId) {
+        return couponJpaRepository.findById(couponId).orElseThrow(() -> new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId)));
     }
 
     public CouponIssue saveCouponIssue(long couponId, long userId) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,18 +16,10 @@ services:
     ports:
       - 3306:3306
     environment:
-      - MYSQL_DATABASE=coupon
-      - MYSQL_USER=/run/secrets/mysql_user
-      - MYSQL_PASSWORD=/run/secrets/mysql_password
-      - MYSQL_ROOT_PASSWORD=/run/secrets/mysql_root_password
-      - TZ=UTC
+      MYSQL_DATABASE : '${MYSQL_DATABASE}'
+      MYSQL_USER : '${MYSQL_USER}'
+      MYSQL_PASSWORD : '${MYSQL_PASSWORD}'
+      MYSQL_ROOT_PASSWORD : '${MYSQL_ROOT_PASSWORD}'
+      TZ : 'UTC'
     volumes:
-      - ./mysql/init:/docker-entrypoint-initdb.d
-
-secrets:
-  mysql_user:
-    external: true
-  mysql_password:
-    external: true
-  mysql_root_password:
-    external: true
+      - ./coupon-core/src/main/resources/sql:/docker-entrypoint-initdb.d

--- a/load-test/docker-compose.yml
+++ b/load-test/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       - "8089:8089"
     volumes:
       - ./:/mnt/locust
-    command: -f /mnt/locust/locustfile-hello.py --master -H http://host.docker.internal:8080
+    command: -f /mnt/locust/locustfile-issueV1.py --master -H http://host.docker.internal:8080
 
   worker:
     image: locustio/locust
     volumes:
       - ./:/mnt/locust
-    command: -f /mnt/locust/locustfile-hello.py --worker --master-host master
+    command: -f /mnt/locust/locustfile-issueV1.py --worker --master-host master

--- a/load-test/locustfile-issueV1.py
+++ b/load-test/locustfile-issueV1.py
@@ -1,0 +1,16 @@
+import random
+from locust import task, FastHttpUser
+
+
+class CouponIssueV1(FastHttpUser):
+    connection_timeout = 10.0
+    network_timeout = 10.0
+
+    @task
+    def issue(self):
+        payload = {
+            "couponId": 1,
+            "userId": random.randint(1, 10000000),
+        }
+        with self.rest("POST", "/v1/issue", json=payload):
+            pass


### PR DESCRIPTION
이전 쿠폰 발급 API에서 locust를 통해 많은 부하를 주는 테스트를 진행했는데, 
쿠폰 발급량이 내가 원하는 만큼 되지 않는 문제점에서 동시성 제어가 이뤄지지 않았다는 점을 알게 됐다.
java 어플리케이션, mysql와 redis는 각각 분산 락 동시성 제어를 구현할 수 있는데,
java 어플리케이션 내 synchronized는 자바 애플리케이션에 종속되는 방법이어서 서버 확장에 문제가 있다.
그래서 redisson과, mysql 두 가지 방법을 구현했다.